### PR TITLE
Add Claude Code prompt exclusion to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ docs/issues/
 
 # Pull request documentation (local only)
 docs/pull_requests/
+
+# Prompts for Claude Code
+docs/prompts/


### PR DESCRIPTION
## Summary
- Claude Code用のプロンプトファイルを除外するため、`docs/prompts/`ディレクトリを`.gitignore`に追加

## Test plan
- [x] `.gitignore`の変更を確認
- [x] `docs/prompts/`ディレクトリがgitのトラッキング対象外になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)